### PR TITLE
mcp: register Claude over HTTP by default, keep stdio as fallback

### DIFF
--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -1290,8 +1290,8 @@ rm -f "$_SCAN_ERR_FILE" 2>/dev/null || true
 echo "[$TOOL_LABEL] Scan complete."
 echo ""
 
-# HTTP server is always started — used by prime.sh hooks and non-Claude assistants.
-# For Claude with stdio, the MCP connection bypasses it (no port dependency).
+# HTTP server is always started — used by Claude (HTTP transport), prime.sh hooks,
+# and non-Claude assistants. Stdio remains only as a compatibility fallback.
 echo "[$TOOL_LABEL] Port    : $MCP_PORT"
 echo ""
 
@@ -1657,49 +1657,56 @@ elif [[ "$ASSISTANT" == "claude" ]]; then
   claude mcp remove dual-graph >/dev/null 2>&1 || true
   _MCP_REG_OK=0
   _MCP_REG_ERR=""
+  _CLAUDE_TRANSPORT=""
 
-  # Stdio mode: Claude Code spawns the MCP server directly — no port needed.
-  if [[ "$_GRAPEROOT_OK" == "1" ]]; then
-    _STDIO_CMD=("$VENV_BIN/mcp-graph-server" "--stdio")
-  else
-    _STDIO_CMD=("$PYTHON" "$SCRIPT_DIR/mcp_graph_server.py" "--stdio")
-  fi
+  # HTTP primary: Claude Code talks to the already-running MCP server over HTTP.
+  _MCP_URL="http://127.0.0.1:$MCP_PORT/mcp"
 
-  if _MCP_REG_ERR="$(claude mcp add dual-graph \
-    -e DG_DATA_DIR="$DATA_DIR" \
-    -e DUAL_GRAPH_PROJECT_ROOT="$PROJECT" \
-    -- "${_STDIO_CMD[@]}" 2>&1)"; then
+  if _MCP_REG_ERR="$(claude mcp add --transport http dual-graph "$_MCP_URL" 2>&1)"; then
     _MCP_REG_OK=1
+    _CLAUDE_TRANSPORT="http"
+  elif _MCP_REG_ERR="$(claude mcp add --transport sse dual-graph "$_MCP_URL" 2>&1)"; then
+    _MCP_REG_OK=1
+    _CLAUDE_TRANSPORT="sse"
+  elif _MCP_REG_ERR="$(claude mcp add dual-graph "$_MCP_URL" 2>&1)"; then
+    _MCP_REG_OK=1
+    _CLAUDE_TRANSPORT="http"
   fi
 
-  # Fallback: if stdio registration fails (old claude CLI), try HTTP
+  # Stdio fallback: older claude CLI without --transport support, or HTTP disabled.
   if [[ "$_MCP_REG_OK" != "1" ]]; then
-    if _MCP_REG_ERR="$(claude mcp add --transport http dual-graph "http://127.0.0.1:$MCP_PORT/mcp" 2>&1)"; then
-      _MCP_REG_OK=1
-      _CLAUDE_NEEDS_HTTP=1
-    elif _MCP_REG_ERR="$(claude mcp add --transport sse dual-graph "http://127.0.0.1:$MCP_PORT/mcp" 2>&1)"; then
-      _MCP_REG_OK=1
-      _CLAUDE_NEEDS_HTTP=1
-    elif _MCP_REG_ERR="$(claude mcp add dual-graph "http://127.0.0.1:$MCP_PORT/mcp" 2>&1)"; then
-      _MCP_REG_OK=1
-      _CLAUDE_NEEDS_HTTP=1
+    if [[ "$_GRAPEROOT_OK" == "1" ]]; then
+      _STDIO_CMD=("$VENV_BIN/mcp-graph-server" "--stdio")
+    else
+      _STDIO_CMD=("$PYTHON" "$SCRIPT_DIR/mcp_graph_server.py" "--stdio")
     fi
-  fi
-
-  if [[ "$_MCP_REG_OK" != "1" ]]; then
-    # Auto-fix: update CLI and retry once
-    echo "[$TOOL_LABEL] MCP registration failed — updating claude CLI and retrying..."
-    npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || true
-    export PATH="$PATH:$(npm config get prefix 2>/dev/null)/bin"
-    claude mcp remove dual-graph >/dev/null 2>&1 || true
     if _MCP_REG_ERR="$(claude mcp add dual-graph \
       -e DG_DATA_DIR="$DATA_DIR" \
       -e DUAL_GRAPH_PROJECT_ROOT="$PROJECT" \
       -- "${_STDIO_CMD[@]}" 2>&1)"; then
       _MCP_REG_OK=1
-    elif _MCP_REG_ERR="$(claude mcp add --transport http dual-graph "http://127.0.0.1:$MCP_PORT/mcp" 2>&1)"; then
+      _CLAUDE_TRANSPORT="stdio"
+    fi
+  fi
+
+  if [[ "$_MCP_REG_OK" != "1" ]]; then
+    # Auto-fix: update CLI and retry once (HTTP-first, stdio as last resort).
+    echo "[$TOOL_LABEL] MCP registration failed — updating claude CLI and retrying..."
+    npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || true
+    export PATH="$PATH:$(npm config get prefix 2>/dev/null)/bin"
+    claude mcp remove dual-graph >/dev/null 2>&1 || true
+    if _MCP_REG_ERR="$(claude mcp add --transport http dual-graph "$_MCP_URL" 2>&1)"; then
       _MCP_REG_OK=1
-      _CLAUDE_NEEDS_HTTP=1
+      _CLAUDE_TRANSPORT="http"
+    elif _MCP_REG_ERR="$(claude mcp add --transport sse dual-graph "$_MCP_URL" 2>&1)"; then
+      _MCP_REG_OK=1
+      _CLAUDE_TRANSPORT="sse"
+    elif _MCP_REG_ERR="$(claude mcp add dual-graph \
+      -e DG_DATA_DIR="$DATA_DIR" \
+      -e DUAL_GRAPH_PROJECT_ROOT="$PROJECT" \
+      -- "${_STDIO_CMD[@]}" 2>&1)"; then
+      _MCP_REG_OK=1
+      _CLAUDE_TRANSPORT="stdio"
     fi
   fi
 
@@ -1714,11 +1721,11 @@ elif [[ "$ASSISTANT" == "claude" ]]; then
     exit 1
   fi
 
-  if [[ "${_CLAUDE_NEEDS_HTTP:-}" == "1" ]]; then
-    echo "[$TOOL_LABEL] MCP config updated -> http://127.0.0.1:$MCP_PORT/mcp (HTTP fallback)"
-  else
-    echo "[$TOOL_LABEL] MCP config updated -> stdio (no port needed)"
-  fi
+  case "$_CLAUDE_TRANSPORT" in
+    http) echo "[$TOOL_LABEL] MCP config updated -> $_MCP_URL (HTTP)" ;;
+    sse)  echo "[$TOOL_LABEL] MCP config updated -> $_MCP_URL (SSE)" ;;
+    stdio) echo "[$TOOL_LABEL] MCP config updated -> stdio (HTTP unavailable, fallback)" ;;
+  esac
 
   # ── Token Counter MCP (global user scope — works in all projects) ────────
   # Kill any leftover token-counter-mcp process so it can reclaim port 8899


### PR DESCRIPTION
## Summary

- Flip Claude MCP registration in `bin/dual_graph_launch.sh` from stdio-first to HTTP-first.
- The HTTP server on `127.0.0.1:$MCP_PORT/mcp` is already started unconditionally (line ~1298+) for `prime.sh` hooks and non-Claude assistants, so Claude can connect to the same endpoint instead of spawning a parallel stdio process.
- Stdio remains in the fallback chain for older `claude` CLI builds that lack `--transport http` support.
- Replace the binary `_CLAUDE_NEEDS_HTTP` flag with `_CLAUDE_TRANSPORT` (`http|sse|stdio`) so the final log line tells the user exactly which transport was registered.

## Why

In some environments the stdio transport never establishes a session with Claude Code (no errors surfaced, MCP just sits disconnected) even though the HTTP server is healthy. Since HTTP is the canonical transport every other consumer of the dual-graph already uses, treating it as the Claude default removes a class of "MCP disconnected" reports without losing compatibility — stdio falls through automatically if the HTTP registration step fails.

## Behavior

- `claude mcp add --transport http` → tried first
- `--transport sse` → second
- bare URL form → third
- stdio (`-- mcp-graph-server --stdio`) → last resort, kept inside the auto-fix retry block too

Final user-facing log:
```
[dgc] MCP config updated -> http://127.0.0.1:8081/mcp (HTTP)
```
(or `(SSE)` / `stdio (HTTP unavailable, fallback)` depending on which branch won).

## Test plan

- [x] `bash -n bin/dual_graph_launch.sh` — syntax OK
- [x] Manual run of `dgc` on Ubuntu — Claude connects via HTTP, MCP tools available
- [ ] Manual run on macOS to confirm no regression
- [ ] Confirm older `claude` CLI (without `--transport`) still works via stdio fallback