### PR TITLE
Add Kiro and Command Code assistant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[graperoot.dev](https://graperoot.dev)** · [Docs](https://graperoot.dev/docs) · [Benchmarks](https://graperoot.dev/benchmarks) · [Pro](https://graperoot.dev/graperoot-pro) · [Discord](https://discord.com/invite/YwKdQATY2d) · [Troubleshooting](./TROUBLESHOOTING.md)
 
-A context engine that makes Claude Code, Codex CLI, Gemini CLI, Cursor, OpenCode, and GitHub Copilot **30-45% cheaper** without sacrificing quality. It builds a semantic graph of your codebase and pre-loads the right files into every prompt — so your AI spends tokens reasoning, not exploring.
+A context engine that makes Claude Code, Codex CLI, Gemini CLI, Cursor, OpenCode, Kiro CLI, Command Code, and GitHub Copilot **30-45% cheaper** without sacrificing quality. It builds a semantic graph of your codebase and pre-loads the right files into every prompt — so your AI spends tokens reasoning, not exploring.
 
 Works on **macOS, Linux, and Windows**. Supports any project size.
 
@@ -100,6 +100,8 @@ graperoot . --opencode           # OpenCode
 graperoot . --copilot            # GitHub Copilot
 graperoot . --antigravity        # Google Antigravity
 graperoot . --codex              # Codex CLI
+graperoot . --kiro               # Kiro CLI
+graperoot . --command-code       # Command Code
 graperoot /path/to/project --cursor           # specific project
 graperoot /path/to/project --gemini "add tests"  # with a prompt
 ```

--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -629,6 +629,14 @@ elif [[ "$ASSISTANT" == "openclaw" ]]; then
   DOC_FILE="$PROJECT/AGENTS.md"
   DOC_NAME="AGENTS.md"
   POLICY_MARKER="dgc-policy-v11"
+elif [[ "$ASSISTANT" == "kiro" ]]; then
+  DOC_FILE="$PROJECT/AGENTS.md"
+  DOC_NAME="AGENTS.md"
+  POLICY_MARKER="dgc-policy-v11"
+elif [[ "$ASSISTANT" == "command-code" ]]; then
+  DOC_FILE="$PROJECT/AGENTS.md"
+  DOC_NAME="AGENTS.md"
+  POLICY_MARKER="dgc-policy-v11"
 else
   # claude, copilot share CLAUDE.md as their context policy file
   DOC_FILE="$PROJECT/CLAUDE.md"
@@ -2370,6 +2378,97 @@ PY
   echo "[$TOOL_LABEL] MCP URL: $_OC_URL"
 fi
 
+# -- Kiro CLI: write .kiro/settings/mcp.json and launch -----------------------
+if [[ "$ASSISTANT" == "kiro" ]]; then
+  CURRENT_STEP="Registering MCP (Kiro CLI)"
+
+  if ! command -v kiro-cli &>/dev/null; then
+    echo "[$TOOL_LABEL] kiro-cli not found — installing..."
+    if command -v brew &>/dev/null; then
+      brew install --cask kiro 2>/dev/null || true
+    fi
+    export PATH="$PATH:$HOME/.local/bin:/usr/local/bin"
+    if ! command -v kiro-cli &>/dev/null; then
+      echo "[$TOOL_LABEL] ERROR: could not auto-install kiro-cli."
+      echo "[$TOOL_LABEL]   Visit https://kiro.dev/downloads/ to install manually."
+      _send_cli_error "Registering MCP" "kiro-cli not found, auto-install failed"
+      exit 1
+    fi
+    echo "[$TOOL_LABEL] kiro-cli installed."
+  fi
+
+  # Write .kiro/settings/mcp.json (workspace scope)
+  mkdir -p "$PROJECT/.kiro/settings"
+  "$PYTHON" - "$PROJECT/.kiro/settings/mcp.json" "$MCP_PORT" <<'PY'
+import json, sys, os
+config_file = sys.argv[1]
+port = sys.argv[2]
+existing = {}
+if os.path.exists(config_file):
+    try:
+        with open(config_file, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+servers = existing.get("mcpServers", {})
+servers["dual-graph"] = {"url": f"http://127.0.0.1:{port}/mcp"}
+existing["mcpServers"] = servers
+with open(config_file, "w", encoding="utf-8") as f:
+    json.dump(existing, f, indent=2)
+    f.write("\n")
+PY
+  echo "[$TOOL_LABEL] MCP config written -> $PROJECT/.kiro/settings/mcp.json"
+  echo "[$TOOL_LABEL] MCP URL: http://127.0.0.1:$MCP_PORT/mcp"
+fi
+
+# -- Command Code: register MCP and launch ------------------------------------
+if [[ "$ASSISTANT" == "command-code" ]]; then
+  CURRENT_STEP="Registering MCP (Command Code)"
+
+  if ! command -v cmd &>/dev/null || ! cmd --version 2>/dev/null | grep -qi "command.code"; then
+    echo "[$TOOL_LABEL] command-code (cmd) not found — installing..."
+    if command -v npm &>/dev/null; then
+      npm install -g command-code >/dev/null 2>&1 || true
+    fi
+    export PATH="$PATH:$(npm config get prefix 2>/dev/null)/bin:$HOME/.npm-global/bin:$HOME/.local/bin"
+    if ! command -v cmd &>/dev/null; then
+      echo "[$TOOL_LABEL] ERROR: could not auto-install command-code."
+      echo "[$TOOL_LABEL]   npm install -g command-code"
+      _send_cli_error "Registering MCP" "command-code CLI not found, auto-install failed"
+      exit 1
+    fi
+    echo "[$TOOL_LABEL] command-code installed."
+  fi
+
+  _CC_URL="http://127.0.0.1:$MCP_PORT/mcp"
+  if cmd mcp add --transport http dual-graph "$_CC_URL" --scope user 2>/dev/null; then
+    echo "[$TOOL_LABEL] MCP server registered via cmd CLI."
+  else
+    # Fallback: write directly to ~/.commandcode/mcp.json
+    mkdir -p "$HOME/.commandcode"
+    "$PYTHON" - "$HOME/.commandcode/mcp.json" "$MCP_PORT" <<'PY'
+import json, sys, os
+config_file = sys.argv[1]
+port = sys.argv[2]
+existing = {}
+if os.path.exists(config_file):
+    try:
+        with open(config_file, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+servers = existing.get("mcpServers", {})
+servers["dual-graph"] = {"transport": "http", "url": f"http://127.0.0.1:{port}/mcp"}
+existing["mcpServers"] = servers
+with open(config_file, "w", encoding="utf-8") as f:
+    json.dump(existing, f, indent=2)
+    f.write("\n")
+PY
+    echo "[$TOOL_LABEL] MCP config written -> ~/.commandcode/mcp.json"
+  fi
+  echo "[$TOOL_LABEL] MCP URL: $_CC_URL"
+fi
+
 # ── First-run: show all available commands ────────────────────────────────────
 _INSTALL_DATE_FILE="$SCRIPT_DIR/install_date.txt"
 if [[ ! -f "$_INSTALL_DATE_FILE" ]]; then
@@ -2387,6 +2486,8 @@ if [[ ! -f "$_INSTALL_DATE_FILE" ]]; then
   echo "  graperoot [path] --copilot      GitHub Copilot (VS Code)"
   echo "  graperoot [path] --antigravity  Google Antigravity"
   echo "  graperoot [path] --openclaw     OpenClaw"
+  echo "  graperoot [path] --kiro         Kiro CLI"
+  echo "  graperoot [path] --command-code Command Code"
   echo ""
   echo "  Shortcuts:"
   echo "    dgc [path]   →  graperoot [path] --claude"
@@ -2595,7 +2696,7 @@ fi
 # 3. Quick smoke test — verify CLI responds (catches broken installs, missing deps)
 # cursor is validated via CURSOR_BIN at registration time; skip --version check for it.
 _SMOKE_BIN="${CURSOR_BIN:-${CODE_BIN:-$ASSISTANT}}"
-if [[ "$ASSISTANT" != "cursor" && "$ASSISTANT" != "copilot" && "$ASSISTANT" != "antigravity" && "$ASSISTANT" != "openclaw" ]] && ! "$_SMOKE_BIN" --version &>/dev/null 2>&1; then
+if [[ "$ASSISTANT" != "cursor" && "$ASSISTANT" != "copilot" && "$ASSISTANT" != "antigravity" && "$ASSISTANT" != "openclaw" && "$ASSISTANT" != "kiro" && "$ASSISTANT" != "command-code" ]] && ! "$_SMOKE_BIN" --version &>/dev/null 2>&1; then
   echo "[$TOOL_LABEL] WARNING: '$ASSISTANT --version' failed. The CLI may not work correctly."
   case "$ASSISTANT" in
     claude)   echo "[$TOOL_LABEL] Try reinstalling: npm install -g @anthropic-ai/claude-code" ;;
@@ -2680,6 +2781,22 @@ elif [[ "$ASSISTANT" == "openclaw" ]]; then
   _OC_MODEL="${OPENCLAW_DEFAULT_MODEL:-amazon-bedrock/global.anthropic.claude-opus-4-6-v1}"
   _OC_SESSION="agent:main:graperoot-$(basename "$PROJECT")"
   openclaw agent --local --agent main --session-key "$_OC_SESSION" --model "$_OC_MODEL" --thinking off --message "$_OC_MSG" 2>"$RUN_DIR/assistant_stderr.log"
+elif [[ "$ASSISTANT" == "kiro" ]]; then
+  # Kiro CLI — launches interactive chat with trusted tools
+  trap 'echo ""; echo "[$TOOL_LABEL] Shutting down MCP server (PID $MCP_PID)..."; kill "$MCP_PID" 2>/dev/null; rm -f "$RUN_DIR/mcp_server.pid" "$RUN_DIR/mcp_port"; exit 130' INT TERM HUP
+  _LAUNCH_ARGS=(chat --trust-all-tools)
+  [[ -n "$PROMPT" ]] && _LAUNCH_ARGS+=("$PROMPT")
+  kiro-cli "${_LAUNCH_ARGS[@]}" 2>"$RUN_DIR/assistant_stderr.log"
+elif [[ "$ASSISTANT" == "command-code" ]]; then
+  # Command Code — launches interactive session
+  trap 'echo ""; echo "[$TOOL_LABEL] Shutting down MCP server (PID $MCP_PID)..."; kill "$MCP_PID" 2>/dev/null; rm -f "$RUN_DIR/mcp_server.pid" "$RUN_DIR/mcp_port"; exit 130' INT TERM HUP
+  _LAUNCH_ARGS=()
+  [[ -n "$PROMPT" ]] && _LAUNCH_ARGS+=("$PROMPT")
+  if [[ ${#_LAUNCH_ARGS[@]} -gt 0 ]]; then
+    cmd "${_LAUNCH_ARGS[@]}" 2>"$RUN_DIR/assistant_stderr.log"
+  else
+    cmd 2>"$RUN_DIR/assistant_stderr.log"
+  fi
 else
   # Build launch args: optional prompt + all passthrough flags
   _LAUNCH_ARGS=()

--- a/bin/graperoot
+++ b/bin/graperoot
@@ -8,6 +8,8 @@
 #   graperoot [path] --gemini       # Google Gemini CLI
 #   graperoot [path] --antigravity  # Google Antigravity
 #   graperoot [path] --openclaw     # OpenClaw
+#   graperoot [path] --kiro         # Kiro CLI
+#   graperoot [path] --command-code # Command Code
 #
 # The tool flag can come before or after the path.
 # Flags can be written with or without --  (e.g. cursor or --cursor).
@@ -42,6 +44,8 @@ _show_help() {
     --copilot      GitHub Copilot (VS Code)
     --antigravity  Google Antigravity
     --openclaw     OpenClaw
+    --kiro         Kiro CLI
+    --command-code Command Code
 
   Options:
     --resume <id>    Resume a previous claude / codex session
@@ -55,6 +59,8 @@ _show_help() {
     graperoot /my/project --copilot
     graperoot /my/project --antigravity
     graperoot /my/project --openclaw
+    graperoot /my/project --kiro
+    graperoot /my/project --command-code
     graperoot /my/project --claude --resume <session-id>
     dgc .                          # same as graperoot . --claude
     dg  .                          # same as graperoot . --codex
@@ -71,7 +77,7 @@ ASSISTANT="claude"   # default
 PROJECT=""
 PASSTHROUGH=()
 
-_VALID_TOOLS="claude codex cursor gemini opencode copilot antigravity openclaw"
+_VALID_TOOLS="claude codex cursor gemini opencode copilot antigravity openclaw kiro command-code"
 _TOOL_SET=false
 
 ARGS=("$@")
@@ -87,6 +93,8 @@ while (( i < ${#ARGS[@]} )); do
     --copilot|copilot)         ASSISTANT="copilot";     _TOOL_SET=true ;;
     --antigravity|antigravity) ASSISTANT="antigravity"; _TOOL_SET=true ;;
     --openclaw|openclaw)       ASSISTANT="openclaw";    _TOOL_SET=true ;;
+    --kiro|kiro)               ASSISTANT="kiro";        _TOOL_SET=true ;;
+    --command-code|command-code|--commandcode|commandcode) ASSISTANT="command-code"; _TOOL_SET=true ;;
     --toolname)
       PASSTHROUGH+=("$arg")
       if (( i + 1 < ${#ARGS[@]} )) && [[ "${ARGS[$((i + 1))]}" != --* ]]; then

--- a/bin/graperoot.ps1
+++ b/bin/graperoot.ps1
@@ -11,6 +11,8 @@
 #   graperoot [path] --copilot      GitHub Copilot (VS Code)
 #   graperoot [path] --antigravity  Google Antigravity
 #   graperoot [path] --openclaw     OpenClaw
+#   graperoot [path] --kiro         Kiro CLI
+#   graperoot [path] --command-code Command Code
 
 param(
     [Parameter(Position = 0)] [string]$Arg0 = ".",
@@ -25,6 +27,8 @@ param(
     [switch]$copilot,
     [switch]$antigravity,
     [switch]$openclaw,
+    [switch]$kiro,
+    [switch]${command-code},
     [string]$toolname = "graperoot"
 )
 
@@ -85,6 +89,8 @@ if ($Arg0 -in @("--help","-h","?","/?")) {
     Write-Host "    --copilot      GitHub Copilot (VS Code)"
     Write-Host "    --antigravity  Google Antigravity"
     Write-Host "    --openclaw     OpenClaw"
+    Write-Host "    --kiro         Kiro CLI"
+    Write-Host "    --command-code Command Code"
     Write-Host ""
     Write-Host "  Options:"
     Write-Host "    --resume <id>    Resume a previous claude / codex session"
@@ -98,6 +104,8 @@ if ($Arg0 -in @("--help","-h","?","/?")) {
     Write-Host "    graperoot C:\my\project --copilot"
     Write-Host "    graperoot C:\my\project --antigravity"
     Write-Host "    graperoot C:\my\project --openclaw"
+    Write-Host "    graperoot C:\my\project --kiro"
+    Write-Host "    graperoot C:\my\project --command-code"
     Write-Host "    graperoot C:\my\project --claude --resume <session-id>"
     Write-Host "    dgc .                        # same as graperoot . --claude"
     Write-Host "    dg  .                        # same as graperoot . --codex"
@@ -121,7 +129,7 @@ $env:DG_TOOLNAME = $RuntimeToolName
 $Assistant   = "claude"   # default
 $ProjectPath = ""
 $Passthrough = @()
-$_validTools = @("claude","codex","cursor","gemini","opencode","copilot","antigravity","openclaw")
+$_validTools = @("claude","codex","cursor","gemini","opencode","copilot","antigravity","openclaw","kiro","command-code")
 $_toolSet    = $false
 $_inputArgs  = @($Arg0, $Arg1, $Arg2)
 if ($args) { $_inputArgs += $args }
@@ -134,6 +142,8 @@ elseif ($gemini)      { $Assistant = "gemini";       $_toolSet = $true }
 elseif ($copilot)     { $Assistant = "copilot";      $_toolSet = $true }
 elseif ($antigravity) { $Assistant = "antigravity";  $_toolSet = $true }
 elseif ($openclaw)    { $Assistant = "openclaw";     $_toolSet = $true }
+elseif ($kiro)        { $Assistant = "kiro";         $_toolSet = $true }
+elseif (${command-code}) { $Assistant = "command-code"; $_toolSet = $true }
 elseif ($codex)       { $Assistant = "codex";        $_toolSet = $true }
 elseif ($claude)      { $Assistant = "claude";       $_toolSet = $true }
 
@@ -148,6 +158,8 @@ while ($_argIndex -lt $_inputArgs.Count) {
     if ($arg -in @("--copilot","copilot"))       { $Assistant = "copilot";      $_toolSet = $true; $_argIndex++; continue }
     if ($arg -in @("--antigravity","antigravity")) { $Assistant = "antigravity"; $_toolSet = $true; $_argIndex++; continue }
     if ($arg -in @("--openclaw","openclaw"))       { $Assistant = "openclaw";    $_toolSet = $true; $_argIndex++; continue }
+    if ($arg -in @("--kiro","kiro"))               { $Assistant = "kiro";        $_toolSet = $true; $_argIndex++; continue }
+    if ($arg -in @("--command-code","command-code","--commandcode","commandcode")) { $Assistant = "command-code"; $_toolSet = $true; $_argIndex++; continue }
     if ($arg -match '^-{1,2}toolname=(.*)$') {
         $RuntimeToolName = Normalize-ToolName $Matches[1]
         $env:DG_TOOLNAME = $RuntimeToolName
@@ -871,6 +883,120 @@ with open(config_file, 'w', encoding='utf-8') as f:
     Write-Host "[$Tool] Starting openclaw agent..."
     Write-Host ""
     openclaw agent --local --message "I am ready to help. The dual-graph MCP server is connected - use graph_continue to start."
+}
+
+# -- Kiro CLI: write .kiro/settings/mcp.json and launch ------------------------
+if ($Assistant -eq "kiro") {
+    if (-not (Get-Command kiro-cli -ErrorAction SilentlyContinue)) {
+        Write-Host "[$Tool] kiro-cli not found - installing..."
+        try {
+            $kiroInstaller = Invoke-WebRequest "https://kiro.dev/install.ps1" -UseBasicParsing -TimeoutSec 30
+            Invoke-Expression $kiroInstaller.Content
+        } catch {}
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+        if (-not (Get-Command kiro-cli -ErrorAction SilentlyContinue)) {
+            Write-Host "[$Tool] ERROR: could not auto-install kiro-cli."
+            Write-Host "[$Tool]   Visit https://kiro.dev/downloads/ to install manually."
+            Stop-Process -Id $mcpProc.Id -Force -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Write-Host "[$Tool] kiro-cli installed."
+    }
+
+    # Write .kiro/settings/mcp.json (workspace scope)
+    $KiroDir = Join-Path $ProjectPath ".kiro\settings"
+    New-Item -ItemType Directory -Force -Path $KiroDir | Out-Null
+    $KiroConf = Join-Path $KiroDir "mcp.json"
+    $kiroExisting = [PSCustomObject]@{ mcpServers = [PSCustomObject]@{} }
+    if (Test-Path $KiroConf) {
+        try {
+            $parsed = Get-Content $KiroConf -Raw | ConvertFrom-Json
+            if ($parsed) { $kiroExisting = $parsed }
+        } catch {}
+    }
+    if (-not $kiroExisting.mcpServers) {
+        $kiroExisting | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue ([PSCustomObject]@{}) -Force
+    }
+    $kiroExisting.mcpServers | Add-Member -NotePropertyName "dual-graph" `
+        -NotePropertyValue ([PSCustomObject]@{ url = "http://127.0.0.1:$McpPort/mcp" }) -Force
+    $kiroTmp = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($kiroTmp, ($kiroExisting | ConvertTo-Json -Depth 5 -Compress))
+    & $Python -c "import json,sys;d=json.load(open(sys.argv[1]));open(sys.argv[2],'w',encoding='utf-8').write(json.dumps(d,indent=2)+'\n')" $kiroTmp $KiroConf
+    Remove-Item $kiroTmp -ErrorAction SilentlyContinue
+
+    Write-Host "[$Tool] MCP config written -> $KiroConf"
+    Write-Host "[$Tool] MCP URL: http://127.0.0.1:$McpPort/mcp"
+    Write-Host ""
+
+    Set-Location $ProjectPath
+    Write-Host "[$Tool] Starting kiro-cli..."
+    Write-Host ""
+    kiro-cli chat --trust-all-tools
+}
+
+# -- Command Code: register MCP and launch ------------------------------------
+if ($Assistant -eq "command-code") {
+    # Use 'command-code' binary to avoid conflict with Windows cmd.exe
+    $ccBin = "command-code"
+    if (-not (Get-Command command-code -ErrorAction SilentlyContinue)) {
+        Write-Host "[$Tool] command-code not found - installing..."
+        try { npm install -g command-code } catch {}
+        # Refresh PATH
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+        if (-not (Get-Command command-code -ErrorAction SilentlyContinue)) {
+            Write-Host "[$Tool] ERROR: could not auto-install command-code."
+            Write-Host "[$Tool]   npm install -g command-code"
+            Stop-Process -Id $mcpProc.Id -Force -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Write-Host "[$Tool] command-code installed."
+    }
+
+    # Register MCP via command-code mcp add (user scope so it works across projects)
+    $ccUrl = "http://127.0.0.1:$McpPort/mcp"
+    Write-Host "[$Tool] Registering dual-graph MCP server with Command Code..."
+    & $ccBin mcp add --transport http dual-graph $ccUrl --scope user 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        # Fallback: write directly to ~/.commandcode/mcp.json
+        $CcDir = Join-Path $env:USERPROFILE ".commandcode"
+        New-Item -ItemType Directory -Force -Path $CcDir | Out-Null
+        $CcConf = Join-Path $CcDir "mcp.json"
+        $ccExisting = [PSCustomObject]@{ mcpServers = [PSCustomObject]@{} }
+        if (Test-Path $CcConf) {
+            try {
+                $parsed = Get-Content $CcConf -Raw | ConvertFrom-Json
+                if ($parsed) { $ccExisting = $parsed }
+            } catch {}
+        }
+        if (-not $ccExisting.mcpServers) {
+            $ccExisting | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue ([PSCustomObject]@{}) -Force
+        }
+        $ccExisting.mcpServers | Add-Member -NotePropertyName "dual-graph" `
+            -NotePropertyValue ([PSCustomObject]@{ transport = "http"; url = $ccUrl }) -Force
+        $ccTmp = [System.IO.Path]::GetTempFileName()
+        [System.IO.File]::WriteAllText($ccTmp, ($ccExisting | ConvertTo-Json -Depth 5 -Compress))
+        & $Python -c "import json,sys;d=json.load(open(sys.argv[1]));open(sys.argv[2],'w',encoding='utf-8').write(json.dumps(d,indent=2)+'\n')" $ccTmp $CcConf
+        Remove-Item $ccTmp -ErrorAction SilentlyContinue
+        Write-Host "[$Tool] MCP config written -> $CcConf"
+    } else {
+        Write-Host "[$Tool] MCP server registered via cmd CLI."
+    }
+    Write-Host "[$Tool] MCP URL: $ccUrl"
+
+    # Write/append AGENTS.md (Command Code reads rules from AGENTS.md)
+    $AgentsFile = Join-Path $ProjectPath "AGENTS.md"
+    $CcPolicyMarker = "dgc-policy-v11"
+    if ((-not (Test-Path $AgentsFile)) -or (-not (Select-String -Path $AgentsFile -Pattern $CcPolicyMarker -Quiet))) {
+        Write-Host "[$Tool] Writing AGENTS.md policy ..."
+        & $Python -c 'import sys,os;f=sys.argv[1];m=sys.argv[2];existed=os.path.exists(f);content=open(f,"r",encoding="utf-8").read() if existed else "";sep="\n\n" if content and not content.endswith("\n\n") else ("\n" if content and not content.endswith("\n") else "");policy="<!-- "+m+" -->\n# Dual-Graph Context Policy\n\nThis project uses a local dual-graph MCP server for efficient context retrieval.\n\n## MANDATORY: Always follow this order\n\n1. **Call `graph_continue` first** - before any file exploration, grep, or code reading.\n2. **If `graph_continue` returns `needs_project=true`**: call `graph_scan` with the current project directory. Do NOT ask the user.\n3. **If `graph_continue` returns `skip=true`**: project has fewer than 5 files. Do NOT do broad exploration.\n4. **Read `recommended_files`** using `graph_read` - one call per file.\n5. **Check `confidence`** and obey the caps strictly:\n   - high -> Stop. Do NOT grep or explore further.\n   - medium -> At most 2 supplementary greps, then 2 additional files. Then stop.\n   - low -> At most 3 supplementary greps, then 3 additional files. Then stop.\n\n## Rules\n\n- Do NOT use grep or file exploration before calling `graph_continue`.\n- Do NOT do broad/recursive exploration at any confidence level.\n- After edits, call `graph_register_edit(files: [\"path/to/file\"])`.\n";open(f,"w",encoding="utf-8").write(content+sep+policy)' $AgentsFile $CcPolicyMarker
+        Write-Host "[$Tool] AGENTS.md updated."
+    }
+
+    Write-Host ""
+    Set-Location $ProjectPath
+    Write-Host "[$Tool] Starting Command Code..."
+    Write-Host ""
+    & $ccBin
 }
 
 # Cleanup


### PR DESCRIPTION
Introduce support for Kiro CLI and Command Code across the project. Updates README to list new flags, adds handling in dual_graph_launch.sh to register MCP servers (writes .kiro/settings/mcp.json for Kiro and registers/writes ~/.commandcode/mcp.json for Command Code), attempts auto-install of missing CLIs, and launches the appropriate interactive clients. Also updates the smoke-test to allow these tools, appends AGENTS.md policy for Command Code, and adds flags/help/validation in the graperoot shell and PowerShell wrappers.