### PR TITLE
Add MiniMax model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ dgc /path/to/project "fix the login bug" # start with a prompt
 dg                              # scan current directory
 dg /path/to/project             # scan a specific project
 dg /path/to/project "add tests" # start with a prompt
+dg --model=minimax /path/to/project # use MiniMax-M3 via MiniMax's OpenAI-compatible API
 ```
 
 ### Interactive Picker (new in v3.9.99)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,32 @@ dgc /path/to/project "fix the login bug" # start with a prompt
 dg                              # scan current directory
 dg /path/to/project             # scan a specific project
 dg /path/to/project "add tests" # start with a prompt
-dg --model=minimax /path/to/project # use MiniMax-M3 via MiniMax's OpenAI-compatible API
+```
+
+### MiniMax
+
+Set `MINIMAX_API_KEY`, then select either supported model: `MiniMax-M3` or
+`MiniMax-M2.7`. The `minimax` alias uses `MiniMax-M3`.
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+dg --model=minimax /path/to/project
+dg --model=minimax-m3 /path/to/project
+dg --model=minimax-m2.7 /path/to/project
+```
+
+`MINIMAX_REGION` selects the endpoint region and defaults to `global_en`.
+`MINIMAX_API_MODE` selects the compatible API mode and defaults to `openai`;
+set it to `anthropic` to use the Anthropic-compatible endpoint.
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
+|--------|----------------------------|-------------------------------|
+| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic/v1` |
+| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic/v1` |
+
+```bash
+MINIMAX_REGION=cn_zh dg --model=minimax-m3 /path/to/project
+MINIMAX_API_MODE=anthropic dgc --model=minimax-m2.7 /path/to/project
 ```
 
 ### Interactive Picker (new in v3.9.99)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ dg --model=minimax-m2.7 /path/to/project
 
 `MINIMAX_REGION` selects the endpoint region and defaults to `global_en`.
 `MINIMAX_API_MODE` selects the compatible API mode and defaults to `openai`;
-set it to `anthropic` to use the Anthropic-compatible endpoint.
+set it to `anthropic` to use the Anthropic-compatible endpoint. The launcher
+uses a 1,000,000-token context window for `MiniMax-M3` and a 204,800-token
+context window for `MiniMax-M2.7`.
 
 | Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
 |--------|----------------------------|-------------------------------|

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ set it to `anthropic` to use the Anthropic-compatible endpoint.
 
 | Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
 |--------|----------------------------|-------------------------------|
-| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic/v1` |
-| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic/v1` |
+| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
 
 ```bash
 MINIMAX_REGION=cn_zh dg --model=minimax-m3 /path/to/project

--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -280,11 +280,11 @@ if [[ -n "$FAILOVER_MODEL" ]]; then
       case "${MINIMAX_REGION:-global_en}" in
         global_en)
           _MINIMAX_OPENAI_BASE_URL="https://api.minimax.io/v1"
-          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic/v1"
+          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic"
           ;;
         cn_zh)
           _MINIMAX_OPENAI_BASE_URL="https://api.minimaxi.com/v1"
-          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimaxi.com/anthropic/v1"
+          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimaxi.com/anthropic"
           ;;
         *)
           echo "[dgc] MINIMAX_REGION must be global_en or cn_zh" >&2

--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -274,9 +274,19 @@ if [[ -n "$FAILOVER_MODEL" ]]; then
     openclaw)        ASSISTANT="openclaw" ;;
     minimax|MiniMax-M3|minimax-m3|MiniMax-M2.7|minimax-m2.7)
       case "$FAILOVER_MODEL" in
-        minimax|MiniMax-M3|minimax-m3) _MINIMAX_MODEL="MiniMax-M3" ;;
-        *)                              _MINIMAX_MODEL="MiniMax-M2.7" ;;
+        minimax|MiniMax-M3|minimax-m3)
+          _MINIMAX_MODEL="MiniMax-M3"
+          _MINIMAX_CONTEXT_WINDOW=1000000
+          ;;
+        *)
+          _MINIMAX_MODEL="MiniMax-M2.7"
+          _MINIMAX_CONTEXT_WINDOW=204800
+          ;;
       esac
+      if [[ -z "${MINIMAX_API_KEY:-}" ]]; then
+        echo "[dgc] MINIMAX_API_KEY must be set" >&2
+        exit 2
+      fi
       case "${MINIMAX_REGION:-global_en}" in
         global_en)
           _MINIMAX_OPENAI_BASE_URL="https://api.minimax.io/v1"
@@ -294,23 +304,29 @@ if [[ -n "$FAILOVER_MODEL" ]]; then
       case "${MINIMAX_API_MODE:-openai}" in
         openai)
           ASSISTANT="codex"
-          export OPENAI_BASE_URL="$_MINIMAX_OPENAI_BASE_URL"
-          [[ -n "${MINIMAX_API_KEY:-}" ]] && export OPENAI_API_KEY="$MINIMAX_API_KEY"
+          CLAUDE_EXTRA_ARGS+=(
+            --model "$_MINIMAX_MODEL"
+            -c 'model_provider="minimax"'
+            -c 'model_providers.minimax.name="MiniMax"'
+            -c "model_providers.minimax.base_url=\"$_MINIMAX_OPENAI_BASE_URL\""
+            -c 'model_providers.minimax.env_key="MINIMAX_API_KEY"'
+            -c 'model_providers.minimax.wire_api="responses"'
+            -c "model_context_window=$_MINIMAX_CONTEXT_WINDOW"
+          )
           ;;
         anthropic)
           ASSISTANT="claude"
           export ANTHROPIC_BASE_URL="$_MINIMAX_ANTHROPIC_BASE_URL"
-          if [[ -n "${MINIMAX_API_KEY:-}" ]]; then
-            export ANTHROPIC_API_KEY="$MINIMAX_API_KEY"
-            export ANTHROPIC_AUTH_TOKEN="$MINIMAX_API_KEY"
-          fi
+          unset ANTHROPIC_API_KEY
+          export ANTHROPIC_AUTH_TOKEN="$MINIMAX_API_KEY"
+          export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$_MINIMAX_CONTEXT_WINDOW"
+          CLAUDE_EXTRA_ARGS+=(--model "$_MINIMAX_MODEL")
           ;;
         *)
           echo "[dgc] MINIMAX_API_MODE must be openai or anthropic" >&2
           exit 2
           ;;
       esac
-      CLAUDE_EXTRA_ARGS+=(--model "$_MINIMAX_MODEL")
       ;;
     local|ollama)
       ASSISTANT="codex"

--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -212,7 +212,7 @@ RESUME_ID=""
 PROMPT=""
 CLAUDE_EXTRA_ARGS=()
 _PROJECT_SET=false
-FAILOVER_MODEL=""  # set by --model=codex|local|gemini|opencode
+FAILOVER_MODEL=""  # set by --model=codex|local|gemini|opencode|minimax
 NO_GITIGNORE=false
 CONTEXT_POLICY_FILE=""
 RUNTIME_TOOLNAME_RAW=""
@@ -222,7 +222,7 @@ _FILTERED=()
 for _fa in "$@"; do
   if [[ "$_fa" == --model=codex || "$_fa" == --model=local || "$_fa" == --model=ollama \
      || "$_fa" == --model=gemini || "$_fa" == --model=opencode || "$_fa" == --model=antigravity \
-     || "$_fa" == --model=openclaw ]]; then
+     || "$_fa" == --model=openclaw || "$_fa" == --model=minimax ]]; then
     FAILOVER_MODEL="${_fa#--model=}"
   else
     _FILTERED+=("$_fa")
@@ -269,6 +269,11 @@ if [[ -n "$FAILOVER_MODEL" ]]; then
     opencode)        ASSISTANT="opencode" ;;
     antigravity)     ASSISTANT="antigravity" ;;
     openclaw)        ASSISTANT="openclaw" ;;
+    minimax)
+      ASSISTANT="codex"
+      export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://api.minimax.io/v1}"
+      export OPENAI_DEFAULT_MODEL="${OPENAI_DEFAULT_MODEL:-MiniMax-M3}"
+      ;;
     local|ollama)
       ASSISTANT="codex"
       export OPENAI_BASE_URL="http://localhost:11434/v1"

--- a/bin/dual_graph_launch.sh
+++ b/bin/dual_graph_launch.sh
@@ -212,7 +212,7 @@ RESUME_ID=""
 PROMPT=""
 CLAUDE_EXTRA_ARGS=()
 _PROJECT_SET=false
-FAILOVER_MODEL=""  # set by --model=codex|local|gemini|opencode|minimax
+FAILOVER_MODEL=""  # set by --model=codex|local|gemini|opencode|minimax*
 NO_GITIGNORE=false
 CONTEXT_POLICY_FILE=""
 RUNTIME_TOOLNAME_RAW=""
@@ -220,13 +220,16 @@ RUNTIME_TOOLNAME_RAW=""
 # ── Strip --model flag before Claude's own flag parser sees it ────────────────
 _FILTERED=()
 for _fa in "$@"; do
-  if [[ "$_fa" == --model=codex || "$_fa" == --model=local || "$_fa" == --model=ollama \
-     || "$_fa" == --model=gemini || "$_fa" == --model=opencode || "$_fa" == --model=antigravity \
-     || "$_fa" == --model=openclaw || "$_fa" == --model=minimax ]]; then
-    FAILOVER_MODEL="${_fa#--model=}"
-  else
-    _FILTERED+=("$_fa")
-  fi
+  case "$_fa" in
+    --model=codex|--model=local|--model=ollama|--model=gemini|--model=opencode|\
+    --model=antigravity|--model=openclaw|--model=minimax|--model=minimax-m3|\
+    --model=MiniMax-M3|--model=minimax-m2.7|--model=MiniMax-M2.7)
+      FAILOVER_MODEL="${_fa#--model=}"
+      ;;
+    *)
+      _FILTERED+=("$_fa")
+      ;;
+  esac
 done
 [[ ${#_FILTERED[@]} -gt 0 ]] && set -- "${_FILTERED[@]}"
 
@@ -269,10 +272,45 @@ if [[ -n "$FAILOVER_MODEL" ]]; then
     opencode)        ASSISTANT="opencode" ;;
     antigravity)     ASSISTANT="antigravity" ;;
     openclaw)        ASSISTANT="openclaw" ;;
-    minimax)
-      ASSISTANT="codex"
-      export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://api.minimax.io/v1}"
-      export OPENAI_DEFAULT_MODEL="${OPENAI_DEFAULT_MODEL:-MiniMax-M3}"
+    minimax|MiniMax-M3|minimax-m3|MiniMax-M2.7|minimax-m2.7)
+      case "$FAILOVER_MODEL" in
+        minimax|MiniMax-M3|minimax-m3) _MINIMAX_MODEL="MiniMax-M3" ;;
+        *)                              _MINIMAX_MODEL="MiniMax-M2.7" ;;
+      esac
+      case "${MINIMAX_REGION:-global_en}" in
+        global_en)
+          _MINIMAX_OPENAI_BASE_URL="https://api.minimax.io/v1"
+          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic/v1"
+          ;;
+        cn_zh)
+          _MINIMAX_OPENAI_BASE_URL="https://api.minimaxi.com/v1"
+          _MINIMAX_ANTHROPIC_BASE_URL="https://api.minimaxi.com/anthropic/v1"
+          ;;
+        *)
+          echo "[dgc] MINIMAX_REGION must be global_en or cn_zh" >&2
+          exit 2
+          ;;
+      esac
+      case "${MINIMAX_API_MODE:-openai}" in
+        openai)
+          ASSISTANT="codex"
+          export OPENAI_BASE_URL="$_MINIMAX_OPENAI_BASE_URL"
+          [[ -n "${MINIMAX_API_KEY:-}" ]] && export OPENAI_API_KEY="$MINIMAX_API_KEY"
+          ;;
+        anthropic)
+          ASSISTANT="claude"
+          export ANTHROPIC_BASE_URL="$_MINIMAX_ANTHROPIC_BASE_URL"
+          if [[ -n "${MINIMAX_API_KEY:-}" ]]; then
+            export ANTHROPIC_API_KEY="$MINIMAX_API_KEY"
+            export ANTHROPIC_AUTH_TOKEN="$MINIMAX_API_KEY"
+          fi
+          ;;
+        *)
+          echo "[dgc] MINIMAX_API_MODE must be openai or anthropic" >&2
+          exit 2
+          ;;
+      esac
+      CLAUDE_EXTRA_ARGS+=(--model "$_MINIMAX_MODEL")
       ;;
     local|ollama)
       ASSISTANT="codex"


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add routing aliases for MiniMax-M3 and MiniMax-M2.7.
- Add global_en and cn_zh endpoint selection for both supported API modes.
- Configure an invocation-scoped Responses provider for OpenAI mode and bearer-token authentication for Anthropic mode.
- Apply each model's context window and document environment configuration and endpoint selection.

## Checks
- bash -n bin/dual_graph_launch.sh
- git diff --check
- Official source assertions for both models, context windows, pricing tiers, modalities, thinking behavior, and all four endpoint URLs
- Shell routing assertions for both models and every region/API-mode combination
- Real client request captures for /v1/responses and /anthropic/v1/messages
- Secret and English-only scans over the full pull request diff
